### PR TITLE
Planet of Lana TAA fix

### DIFF
--- a/Windows-Game-Patches.sln
+++ b/Windows-Game-Patches.sln
@@ -15,6 +15,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BFV.NoTAA", "source\BFV.NoT
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LiesOfP.NoTAA", "source\LiesOfP.NoTAA\LiesOfP.NoTAA.vcxproj", "{1F44305C-7C31-47AC-8707-02F22D32814A}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PlanetOfLana.NoTAA", "source\PlanetOfLana.NoTAA\PlanetOfLana.NoTAA.vcxproj", "{69D04390-9547-4976-A79E-A4518B9DC923}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -71,6 +73,14 @@ Global
 		{1F44305C-7C31-47AC-8707-02F22D32814A}.Release|x64.Build.0 = Release|x64
 		{1F44305C-7C31-47AC-8707-02F22D32814A}.Release|x86.ActiveCfg = Release|Win32
 		{1F44305C-7C31-47AC-8707-02F22D32814A}.Release|x86.Build.0 = Release|Win32
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Debug|x64.ActiveCfg = Debug|x64
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Debug|x64.Build.0 = Debug|x64
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Debug|x86.ActiveCfg = Debug|Win32
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Debug|x86.Build.0 = Debug|Win32
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Release|x64.ActiveCfg = Release|x64
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Release|x64.Build.0 = Release|x64
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Release|x86.ActiveCfg = Release|Win32
+		{69D04390-9547-4976-A79E-A4518B9DC923}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.sln
+++ b/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33424.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PlanetOfLana.NoTAA", "PlanetOfLana.NoTAA.vcxproj", "{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x64.ActiveCfg = Debug|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x64.Build.0 = Debug|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x86.ActiveCfg = Debug|Win32
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x86.Build.0 = Debug|Win32
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x64.ActiveCfg = Release|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x64.Build.0 = Release|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x86.ActiveCfg = Release|Win32
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CDD207AD-54BC-44A9-933A-5DFEDBD97F44}
+	EndGlobalSection
+EndGlobal

--- a/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj
+++ b/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{ab7a871d-2a06-48c6-863f-b8a0fe8f8e0b}</ProjectGuid>
+    <RootNamespace>PlanetOfLanaNoTAA</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <ProjectName>PlanetOfLana.NoTAA</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>ClangCL</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>ClangCL</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>\..\include\;$(IncludePath)</IncludePath>
+    <TargetExt>.asi</TargetExt>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>\..\include\;$(IncludePath)</IncludePath>
+    <TargetExt>.asi</TargetExt>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetExt>.asi</TargetExt>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetExt>.asi</TargetExt>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>Default</LanguageStandard_C>
+      <UndefinePreprocessorDefinitions>
+      </UndefinePreprocessorDefinitions>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>Default</LanguageStandard_C>
+      <UndefinePreprocessorDefinitions>
+      </UndefinePreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+    <PreBuildEvent>
+      <Command>call $(MSBuildStartupDirectory)\set_git_ver.cmd</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\Shared\helper.cpp" />
+    <ClCompile Include="..\Shared\memory.cpp" />
+    <ClCompile Include="..\Shared\stdafx.cpp" />
+    <ClCompile Include="dllmain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\helper.hpp" />
+    <ClInclude Include="..\..\include\memory.hpp" />
+    <ClInclude Include="..\..\include\stdafx.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj
+++ b/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
-    <ProjectGuid>{ab7a871d-2a06-48c6-863f-b8a0fe8f8e0b}</ProjectGuid>
+    <ProjectGuid>{69D04390-9547-4976-A79E-A4518B9DC923}</ProjectGuid>
     <RootNamespace>PlanetOfLanaNoTAA</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <ProjectName>PlanetOfLana.NoTAA</ProjectName>

--- a/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj.filters
+++ b/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj.filters
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Shared\stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Shared\helper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Shared\memory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\helper.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\memory.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj.user
+++ b/source/PlanetOfLana.NoTAA/PlanetOfLana.NoTAA.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/source/PlanetOfLana.NoTAA/d3d11.ini
+++ b/source/PlanetOfLana.NoTAA/d3d11.ini
@@ -1,0 +1,11 @@
+[GlobalSets]
+LoadPlugins=1
+LoadFromScriptsOnly=0
+DontLoadFromDllMain=0
+FindModule=0
+UseD3D8to9=0
+DisableCrashDumps=0
+Direct3D8DisableMaximizedWindowedModeShim=0
+
+[FileLoader]
+OverloadFromFolder = update

--- a/source/PlanetOfLana.NoTAA/dllmain.cpp
+++ b/source/PlanetOfLana.NoTAA/dllmain.cpp
@@ -1,0 +1,93 @@
+#include "stdafx.h"
+#include "helper.hpp"
+#include "memory.hpp"
+#include "git_ver.h"
+
+HMODULE baseModule = GetModuleHandle(L"GameAssembly.dll");
+
+#define wstr(s) L#s
+#define wxstr(s) wstr(s)
+#define _PROJECT_NAME L"PlanetOfLana.NoTAA"
+#define _PROJECT_LOG_PATH _PROJECT_NAME L".log"
+
+wchar_t exePath[_MAX_PATH] = { 0 };
+
+// INI Variables
+bool bDisableTAA;
+
+void ReadConfig(void)
+{
+    inipp::Ini<wchar_t> ini;
+    // Get game name and exe path
+    LOG(_PROJECT_NAME " Built: " __TIME__ " @ " __DATE__ "\n");
+    LOG(L"" GIT_COMMIT "\n");
+    LOG(L"" GIT_VER "\n");
+    LOG(L"" GIT_NUM "\n");
+    LOG(L"Game Name: %s\n", Memory::GetVersionProductName().c_str());
+    LOG(L"Game Path: %s\n", exePath);
+
+    // Initialize config
+    // UE4 games use launchers so config path is relative to launcher
+    std::wstring config_path = _PROJECT_NAME L".ini";
+    std::wifstream iniFile(config_path);
+    if (!iniFile)
+    {
+        // no ini, lets generate one.
+        LOG(L"Failed to load config file.\n");
+        std::wstring ini_defaults = L"[Settings]\n"
+                                    wstr(bDisableTAA)" = true\n";
+        std::wofstream iniFile(config_path);
+        iniFile << ini_defaults;
+        bDisableTAA = true;
+        LOG(L"Created default config file.\n");
+    }
+    else
+    {
+        ini.parse(iniFile);
+        inipp::get_value(ini.sections[L"Settings"], wstr(bDisableTAA), bDisableTAA);
+    }
+
+    // Log config parse
+    LOG(L"%s: %s (%i)\n", wstr(bDisableTAA), GetBoolStr(bDisableTAA) , bDisableTAA);
+}
+
+void DisableTAA(void)
+{
+    const unsigned char patch[] = { 0x33, 0xC0, 0x89, 0x47, 0x28, 0x90, 0x90, 0x90 };
+    WritePatchPattern(L"8B 47 28 83 F8 01 74 22 83 F8 02", patch, sizeof(patch), L"Disable TAA", 0);
+}
+
+DWORD __stdcall Main(void*)
+{
+    bLoggingEnabled = false;
+    bDisableTAA = false;
+    wchar_t LogPath[_MAX_PATH] = { 0 };
+    wcscpy_s(exePath, _countof(exePath), GetRunningPath(exePath));
+    _snwprintf_s(LogPath, _countof(LogPath), _TRUNCATE, L"%s\\%s", exePath, _PROJECT_LOG_PATH);
+    LoggingInit(_PROJECT_NAME, LogPath);
+    ReadConfig();
+    if (bDisableTAA)
+        DisableTAA();
+    LOG(L"Shutting down " wstr(fp_log) " file handle.\n");
+    fclose(fp_log);
+    return true;
+}
+
+BOOL APIENTRY DllMain( HMODULE hModule,
+                       DWORD  ul_reason_for_call,
+                       LPVOID lpReserved
+                     )
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+    {
+        CreateThread(NULL, 0, Main, 0, NULL, 0);
+    }
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}

--- a/source/PlanetOfLana.NoTAA/dllmain.cpp
+++ b/source/PlanetOfLana.NoTAA/dllmain.cpp
@@ -63,8 +63,8 @@ DWORD __stdcall Main(void*)
     bDisableTAA = false;
     wchar_t LogPath[_MAX_PATH] = { 0 };
     wcscpy_s(exePath, _countof(exePath), GetRunningPath(exePath));
-    _snwprintf_s(LogPath, _countof(LogPath), _TRUNCATE, L"%s\\%s", exePath, _PROJECT_LOG_PATH);
-    LoggingInit(_PROJECT_NAME, LogPath);
+    _snwprintf_s(LogPath, _countof(LogPath), _TRUNCATE, L"%s\\%s", exePath, L"" _PROJECT_LOG_PATH);
+    LoggingInit(L"" _PROJECT_NAME, LogPath);
     ReadConfig();
     if (bDisableTAA)
         DisableTAA();


### PR DESCRIPTION
Rename dinput8.dll to d3d11.dll and copy d3d11.ini in the game folder. The setting DontLoadFromDllMain=0 in d3d11.ini is mandatory to make the game load the ASI patch without crashing.