### PR TITLE
Remnant 2 TAA and Sharpness Fix

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -79,6 +79,28 @@
   - Rename `dinput8.dll` to `winmm.dll`
   - `WoLong.Fix.asi`
 
+### **Planet of Lana**
+  - Disable TAA
+
+#### Installation
+
+- **Note:** ***Please make sure any executable hex edits are removed/reverted first***.
+  - Extract the following contents of the release zip in to the the game root folder.
+  - Rename `dinput8.dll` to `d3d11.dll`
+  - `PlanetOfLana.NoTAA.asi`
+  - `d3d11.ini`
+
+### **Remnant II**
+  - Disable TAA
+  - Disable Sharpness
+
+#### Installation
+
+- **Note:** ***Please make sure any executable hex edits are removed/reverted first***.
+  - Extract the following contents of the release zip in to the the Win64 folder. (`Remnant 2\Remnant2\Binaries\Win64\`).
+  - Rename `dinput8.dll` to `winmm.dll`
+  - `Remnant2.NoTAA.asi`
+
 # Credits
 - [Lyall](https://github.com/Lyall) for Project Template.
 - [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader) for ASI loading.

--- a/Windows-Game-Patches.sln
+++ b/Windows-Game-Patches.sln
@@ -17,6 +17,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LiesOfP.NoTAA", "source\Lie
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PlanetOfLana.NoTAA", "source\PlanetOfLana.NoTAA\PlanetOfLana.NoTAA.vcxproj", "{69D04390-9547-4976-A79E-A4518B9DC923}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Remnant2.NoTAA", "source\Remnant2.NoTAA\Remnant2.NoTAA.vcxproj", "{F56FB0DE-76BA-4227-A9D2-863A36AAD495}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -81,6 +83,14 @@ Global
 		{69D04390-9547-4976-A79E-A4518B9DC923}.Release|x64.Build.0 = Release|x64
 		{69D04390-9547-4976-A79E-A4518B9DC923}.Release|x86.ActiveCfg = Release|Win32
 		{69D04390-9547-4976-A79E-A4518B9DC923}.Release|x86.Build.0 = Release|Win32
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Debug|x64.ActiveCfg = Debug|x64
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Debug|x64.Build.0 = Debug|x64
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Debug|x86.ActiveCfg = Debug|Win32
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Debug|x86.Build.0 = Debug|Win32
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Release|x64.ActiveCfg = Release|x64
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Release|x64.Build.0 = Release|x64
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Release|x86.ActiveCfg = Release|Win32
+		{F56FB0DE-76BA-4227-A9D2-863A36AAD495}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Remnant2.NoTAA/Remnant2.NoTAA.sln
+++ b/source/Remnant2.NoTAA/Remnant2.NoTAA.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33424.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Remnant2.NoTAA", "Remnant2.NoTAA.vcxproj", "{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x64.ActiveCfg = Debug|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x64.Build.0 = Debug|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x86.ActiveCfg = Debug|Win32
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Debug|x86.Build.0 = Debug|Win32
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x64.ActiveCfg = Release|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x64.Build.0 = Release|x64
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x86.ActiveCfg = Release|Win32
+		{AB7A871D-2A06-48C6-863F-B8A0FE8F8E0B}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CDD207AD-54BC-44A9-933A-5DFEDBD97F44}
+	EndGlobalSection
+EndGlobal

--- a/source/Remnant2.NoTAA/Remnant2.NoTAA.vcxproj
+++ b/source/Remnant2.NoTAA/Remnant2.NoTAA.vcxproj
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{F56FB0DE-76BA-4227-A9D2-863A36AAD495}</ProjectGuid>
+    <RootNamespace>Remnant2NoTAA</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <ProjectName>Remnant2.NoTAA</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>ClangCL</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>ClangCL</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>\..\include\;$(IncludePath)</IncludePath>
+    <TargetExt>.asi</TargetExt>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>\..\include\;$(IncludePath)</IncludePath>
+    <TargetExt>.asi</TargetExt>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetExt>.asi</TargetExt>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetExt>.asi</TargetExt>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>Default</LanguageStandard_C>
+      <UndefinePreprocessorDefinitions>
+      </UndefinePreprocessorDefinitions>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;_USRDLL</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\;..\..\external\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>Default</LanguageStandard_C>
+      <UndefinePreprocessorDefinitions>
+      </UndefinePreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+    <PreBuildEvent>
+      <Command>call $(MSBuildStartupDirectory)\set_git_ver.cmd</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\Shared\helper.cpp" />
+    <ClCompile Include="..\Shared\memory.cpp" />
+    <ClCompile Include="..\Shared\stdafx.cpp" />
+    <ClCompile Include="dllmain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\helper.hpp" />
+    <ClInclude Include="..\..\include\memory.hpp" />
+    <ClInclude Include="..\..\include\stdafx.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/source/Remnant2.NoTAA/Remnant2.NoTAA.vcxproj.filters
+++ b/source/Remnant2.NoTAA/Remnant2.NoTAA.vcxproj.filters
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Shared\stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Shared\helper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Shared\memory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\helper.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\memory.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/source/Remnant2.NoTAA/Remnant2.NoTAA.vcxproj.user
+++ b/source/Remnant2.NoTAA/Remnant2.NoTAA.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/source/Remnant2.NoTAA/dllmain.cpp
+++ b/source/Remnant2.NoTAA/dllmain.cpp
@@ -1,0 +1,118 @@
+#include "stdafx.h"
+#include "helper.hpp"
+#include "memory.hpp"
+#include "git_ver.h"
+
+HMODULE baseModule = GetModuleHandle(NULL);
+
+#define wstr(s) L#s
+#define wxstr(s) wstr(s)
+#define _PROJECT_NAME L"Remnant2.NoTAA"
+#define _PROJECT_LOG_PATH _PROJECT_NAME L".log"
+
+wchar_t exePath[_MAX_PATH] = { 0 };
+
+// INI Variables
+bool bDisableTAA;
+bool bDisableSharpness;
+
+void ReadConfig(void)
+{
+    inipp::Ini<wchar_t> ini;
+    // Get game name and exe path
+    LOG(_PROJECT_NAME " Built: " __TIME__ " @ " __DATE__ "\n");
+    LOG(L"" GIT_COMMIT "\n");
+    LOG(L"" GIT_VER "\n");
+    LOG(L"" GIT_NUM "\n");
+    LOG(L"Game Name: %s\n", Memory::GetVersionProductName().c_str());
+    LOG(L"Game Path: %s\n", exePath);
+
+    // Initialize config
+    // UE4 games use launchers so config path is relative to launcher
+    std::wstring config_path = _PROJECT_NAME L".ini";
+    std::wifstream iniFile(config_path);
+    if (!iniFile)
+    {
+        // no ini, lets generate one.
+        LOG(L"Failed to load config file.\n");
+        std::wstring ini_defaults = L"[Settings]\n"
+                                    wstr(bDisableTAA)" = true\n"
+                                    wstr(bDisableSharpness)" = true\n";
+        std::wofstream iniFile(config_path);
+        iniFile << ini_defaults;
+        bDisableTAA = true;
+        bDisableSharpness = true;
+        LOG(L"Created default config file.\n");
+    }
+    else
+    {
+        ini.parse(iniFile);
+        inipp::get_value(ini.sections[L"Settings"], wstr(bDisableTAA), bDisableTAA);
+        inipp::get_value(ini.sections[L"Settings"], wstr(bDisableSharpness), bDisableSharpness);
+    }
+
+    // Log config parse
+    LOG(L"%s: %s (%i)\n", wstr(bDisableTAA), GetBoolStr(bDisableTAA) , bDisableTAA);
+    LOG(L"%s: %s (%i)\n", wstr(bDisableSharpness), GetBoolStr(bDisableSharpness), bDisableSharpness);
+}
+
+void DisableTAA(void)
+{
+    const unsigned char patch[] = { 0xEB, 0x02, 0x33, 0xC0, 0x90, 0x90, 0x90 }; 
+    // EB02   | jmp remnant2-win64-shipping.7FF63AD8C7B0 
+    // 33C0   | xor eax, eax
+    // 8B0438 | mov eax, dword ptr ds : [rax + rdi]             --> 90     | nop
+    //                                                              90     | nop
+    //                                                              90     | nop
+    // 85C0   | test eax, eax
+    // 7904   | jns remnant2 - win64 - shipping.7FF63AD8C7BB
+    WritePatchPattern(L"EB 02 33 C0 8B 04 38 85 C0 79 04", patch, sizeof(patch), L"Disable TAA", 0);    //sets r.AntiAliasingMethod=0
+    WritePatchPattern(L"EB 02 33 C0 8B 04 38 85 C0 79 04", patch, sizeof(patch), L"Disable TAA", 0);    //sets r.Mobile.AntiAliasing=0 (not required, but the sub body is the same)
+}
+
+void DisableSharpness(void)
+{
+    const unsigned char patch[] = {0x45, 0x0F, 0x57, 0xED, 0x90, 0x90 }; 
+    // F3440F106804 | movss xmm13,dword ptr ds:[rax+4]  --> 450F57ED | xorps xmm13, xmm13
+    //                                                      90       | nop
+    //                                                      90       | nop
+    // 440F2FEF     | comiss xmm13, xmm7
+    WritePatchPattern(L"F3 44 0F 10 68 04 44 0F 2F EF", patch, sizeof(patch), L"Disable Sharpness", 0); //sets r.ToneMapper.Sharpen=0
+}
+
+DWORD __stdcall Main(void*)
+{
+    bLoggingEnabled = false;
+    bDisableTAA = false;
+    wchar_t LogPath[_MAX_PATH] = { 0 };
+    wcscpy_s(exePath, _countof(exePath), GetRunningPath(exePath));
+    _snwprintf_s(LogPath, _countof(LogPath), _TRUNCATE, L"%s\\%s", exePath, L"" _PROJECT_LOG_PATH);
+    LoggingInit(L"" _PROJECT_NAME, LogPath);
+    ReadConfig();
+    if (bDisableTAA)
+        DisableTAA();
+    if (bDisableSharpness)
+        DisableSharpness();
+    LOG(L"Shutting down " wstr(fp_log) " file handle.\n");
+    fclose(fp_log);
+    return true;
+}
+
+BOOL APIENTRY DllMain( HMODULE hModule,
+                       DWORD  ul_reason_for_call,
+                       LPVOID lpReserved
+                     )
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+    {
+        CreateThread(NULL, 0, Main, 0, NULL, 0);
+    }
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}


### PR DESCRIPTION
- Included fix for Remnant 2
- Updated readme to include Planet of Lana and Remnant 2 fixes

On top of that, can you fix the ini file name and location for the Planet of Lana fix? It'd be better to have it in the folder "PlanetOfLana.NoTAA" together with its asi file, and with the name "d3d11.ini" instead of "PlanetOfLana.NoTAA_d3d11.ini".
I think the following post build commands could work:
```
mkdir $(OutDirFullPath)$(ProjectName)
copy  $(ProjectDir)d3d11.ini $(OutDirFullPath)$(ProjectName)\d3d11.ini
```